### PR TITLE
Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if (MSVC)
     add_definitions(-DPROTOBUF_USE_DLLS)
   endif (BUILD_SHARED_LIBS)
   add_definitions(/wd4244 /wd4267 /wd4018 /wd4355 /wd4800 /wd4251 /wd4996 /wd4146 /wd4305)
+  add_definitions(/MP)
 endif (MSVC)
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,15 @@ if (MSVC)
   configure_file(extract_includes.bat.in extract_includes.bat)
 endif (MSVC)
 
+if (MSVC)
+  if (CONAN_COMPILER_VERSION STREQUAL "14")
+    # error C2338: <hash_map> is deprecated and will be REMOVED. Please use <unordere
+    # d_map>. You can define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge
+    # that you have received this warning.
+    add_definitions(-D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS)
+  endif ()
+endif (MSVC)
+
 get_filename_component(protobuf_source_dir ${protobuf_SOURCE_DIR} PATH)
 
 include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,41 +4,19 @@ project(protobuf C CXX)
 
 option(BUILD_TESTING "Build tests" ON)
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
-if (MSVC)
-  option(ZLIB "Build with zlib support" OFF)
-endif (MSVC)
 
 add_definitions(-DGOOGLE_PROTOBUF_CMAKE_BUILD)
+add_definitions(-DHAVE_ZLIB)
+
+include(../../conanbuildinfo.cmake)
+conan_basic_setup()
 
 find_package(Threads REQUIRED)
 if (CMAKE_USE_PTHREADS_INIT)
   add_definitions(-DHAVE_PTHREAD)
 endif (CMAKE_USE_PTHREADS_INIT)
 
-if (MSVC)
-  if (ZLIB)
-    set(HAVE_ZLIB 1)
-    find_path(ZLIB_INCLUDE_DIRECTORIES zlib.h ${protobuf_SOURCE_DIR})
-    find_library(ZLIB_LIBRARIES zdll ${protobuf_SOURCE_DIR})
-  else (ZLIB)
-    set(HAVE_ZLIB 0)
-  endif (ZLIB)
-else (MSVC)
-  find_package(ZLIB)
-  if (ZLIB_FOUND)
-    set(HAVE_ZLIB 1)
-  else (ZLIB_FOUND)
-    set(HAVE_ZLIB 0)
-    # Explicitly set these to empty (override NOT_FOUND) so cmake doesn't
-    # complain when we use them later.
-    set(ZLIB_INCLUDE_DIRECTORIES)
-    set(ZLIB_LIBRARIES)
-  endif (ZLIB_FOUND)
-endif (MSVC)
-
-if (HAVE_ZLIB)
-  add_definitions(-DHAVE_ZLIB)
-endif (HAVE_ZLIB)
+set(HAVE_ZLIB 1)
 
 if (MSVC)
   if (BUILD_SHARED_LIBS)
@@ -65,7 +43,7 @@ endif (MSVC)
 get_filename_component(protobuf_source_dir ${protobuf_SOURCE_DIR} PATH)
 
 include_directories(
-  ${ZLIB_INCLUDE_DIRECTORIES}
+  ${CONAN_INCLUDE_DIRS}
   ${protobuf_BINARY_DIR}
   ${protobuf_source_dir}/src
   ../vsprojects)

--- a/build.py
+++ b/build.py
@@ -1,21 +1,41 @@
+from conan.packager import ConanMultiPackager
 import platform
-import os
-
-
-def system(command):
-    retcode = os.system(command)
-    if retcode != 0:
-        raise Exception("Error while executing:\n\t %s" % command)
-
 
 if __name__ == "__main__":
-    system('conan export memsharded/testing')
+    builder = ConanMultiPackager(username = "memsharded", args = "--build missing")
 
     if platform.system() == "Windows":
-        system('conan test -s compiler="Visual Studio" -s compiler.version=12 -s build_type=Debug '
-                          '-s compiler.runtime=MDd')
-        system('conan test -s compiler="Visual Studio" -s compiler.version=12 '
-                          '-s build_type=Release -s compiler.runtime=MD')
+        for compiler_version in ["11", "12", "14"]:
+            for compiler_runtime in ["MT", "MD"]:
+                for build_type in ["Release", "Debug"]:
+                    for arch in ["x86", "x86_64"]:
+                        for static in ["True", "False"]:
+                            if build_type == "Debug" and compiler_runtime == "MT" and static == "False":
+                                # NB: "Debug Assertion Failed!" in protoc.exe, at C++ Runtime "debug_heap.cpp" or "dbgheap.cpp"
+                                # "arch": ["x86", "x86_64"]
+                                # "compiler.version": ["11", 12", "14"]
+                                continue
+
+                            settings = {}
+                            settings["compiler"] = "Visual Studio"
+                            settings["compiler.version"] = compiler_version
+                            settings["build_type"] = build_type
+                            settings["compiler.runtime"] = "%s%s" % (compiler_runtime, "d" if build_type == "Debug" else "")
+                            settings["arch"] = arch
+
+                            options = {}
+                            options["Protobuf:static"] = static
+
+                            builder.add(settings, options)
     else:
-        system('conan test -s compiler="gcc" -s build_type=Debug')
-        system('conan test -s compiler="gcc" -s build_type=Release')
+        for build_type in ["Release", "Debug"]:
+            for static in ["True", "False"]:
+                settings = {}
+                settings["build_type"] = build_type
+
+                options = {}
+                options["Protobuf:static"] = static
+
+                builder.add(settings, options)
+
+    builder.run()

--- a/change_dylib_names.sh
+++ b/change_dylib_names.sh
@@ -1,0 +1,5 @@
+for BINARY in $(find . -type f | grep '\.dylib$') protoc; do
+     for LINK_DESTINATION in $(otool -L $BINARY | grep libproto | cut -f 1 -d' '); do
+         install_name_tool -change "$LINK_DESTINATION" "@executable_path/$(basename $LINK_DESTINATION)" "$BINARY"
+     done
+done

--- a/conanfile.py
+++ b/conanfile.py
@@ -100,6 +100,8 @@ class ProtobufConan(ConanFile):
     def package_info(self):
         if self.settings.os == "Windows":
             self.cpp_info.libs = ["libprotobuf"]
+            if not self.options.static:
+                self.cpp_info.defines = ["PROTOBUF_USE_DLLS"]
         elif self.settings.os == "Macos":
             self.cpp_info.libs = ["libprotobuf.a"] if self.options.static else ["libprotobuf.9.dylib"]
         else:

--- a/conanfile.py
+++ b/conanfile.py
@@ -31,9 +31,11 @@ class ProtobufConan(ConanFile):
 
     def build(self):
         if self.settings.os == "Windows":
+            args = ['-DBUILD_TESTING=OFF']
+            args += ['-DBUILD_SHARED_LIBS=%s' % ('OFF' if self.options.static else 'ON')]
+
             cmake = CMake(self.settings)
-            self.run('cd protobuf-2.6.1/cmake && cmake . %s -DBUILD_TESTING=OFF'
-                     % cmake.command_line)
+            self.run('cd protobuf-2.6.1/cmake && cmake . %s %s' % (cmake.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1/cmake && cmake --build . %s" % cmake.build_config)
         else:
             self.run("chmod +x protobuf-2.6.1/autogen.sh")
@@ -50,7 +52,10 @@ class ProtobufConan(ConanFile):
 
         if self.settings.os == "Windows":
             self.copy("*.lib", "lib", "protobuf-2.6.1/cmake", keep_path=False)
-            self.copy("*/protoc.exe", "bin", "protobuf-2.6.1/cmake", keep_path=False)
+            self.copy("protoc.exe", "bin", "protobuf-2.6.1/cmake/bin", keep_path=False)
+
+            if not self.options.static:
+                self.copy("*.dll", "bin", "protobuf-2.6.1/cmake/bin", keep_path=False)
         else:
             # Copy the libs to lib
             if self.options.static:

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake, tools, ConfigureEnvironment
 import os
 import shutil
 
@@ -43,13 +43,17 @@ class ProtobufConan(ConanFile):
             self.run('cd protobuf-2.6.1/cmake && cmake . %s %s' % (cmake.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1/cmake && cmake --build . %s" % cmake.build_config)
         else:
+            env = ConfigureEnvironment(self.deps_cpp_info, self.settings)
+
             self.run("chmod +x protobuf-2.6.1/autogen.sh")
             self.run("chmod +x protobuf-2.6.1/configure")
             self.run("cd protobuf-2.6.1 && ./autogen.sh")
+
+            args = []
             if self.options.static:
-                self.run("cd protobuf-2.6.1 && ./configure --disable-shared")
-            else:
-                self.run("cd protobuf-2.6.1 && ./configure")
+                args += ['--disable-shared']
+
+            self.run("cd protobuf-2.6.1 && %s ./configure %s" % (env.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1 && make")
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,6 +15,7 @@ class ProtobufConan(ConanFile):
     default_options = "static=False"
     requires = "zlib/1.2.8@lasote/stable"
     generators = "cmake"
+    license = "https://github.com/google/protobuf/blob/v2.6.1/LICENSE"
 
     def config(self):
         self.options["zlib"].shared = not self.options.static

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,6 +45,13 @@ class ProtobufConan(ConanFile):
         else:
             env = ConfigureEnvironment(self.deps_cpp_info, self.settings)
 
+            concurrency = 1
+            try:
+                import multiprocessing
+                concurrency = multiprocessing.cpu_count()
+            except (ImportError, NotImplementedError):
+                pass
+
             self.run("chmod +x protobuf-2.6.1/autogen.sh")
             self.run("chmod +x protobuf-2.6.1/configure")
             self.run("cd protobuf-2.6.1 && ./autogen.sh")
@@ -54,7 +61,7 @@ class ProtobufConan(ConanFile):
                 args += ['--disable-shared']
 
             self.run("cd protobuf-2.6.1 && %s ./configure %s" % (env.command_line, ' '.join(args)))
-            self.run("cd protobuf-2.6.1 && make")
+            self.run("cd protobuf-2.6.1 && make -j %s" % concurrency)
 
     def package(self):
         self.copy_headers("*.h", "protobuf-2.6.1/src")

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,6 +13,11 @@ class ProtobufConan(ConanFile):
     exports = "CMakeLists.txt", "*.cmake", "extract_includes.bat.in"
     options = {"static": [True, False]}
     default_options = "static=False"
+    requires = "zlib/1.2.8@lasote/stable"
+    generators = "cmake"
+
+    def config(self):
+        self.options["zlib"].shared = not self.options.static
 
     def source(self):
         tools.download("https://github.com/google/protobuf/"

--- a/libprotobuf.cmake
+++ b/libprotobuf.cmake
@@ -52,8 +52,12 @@ set(libprotobuf_files
   #${protobuf_source_dir}/src/google/protobuf/wrappers.pb.cc
 )
 
-add_library(libprotobuf ${libprotobuf_lite_files} ${libprotobuf_files})
 target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+if (BUILD_SHARED_LIBS)
+  add_library(libprotobuf SHARED ${libprotobuf_lite_files} ${libprotobuf_files})
+else (BUILD_SHARED_LIBS)
+  add_library(libprotobuf STATIC ${libprotobuf_lite_files} ${libprotobuf_files})
+endif (BUILD_SHARED_LIBS)
 set_target_properties(libprotobuf PROPERTIES
     COMPILE_DEFINITIONS LIBPROTOBUF_EXPORTS
     OUTPUT_NAME ${LIB_PREFIX}protobuf)

--- a/libprotobuf.cmake
+++ b/libprotobuf.cmake
@@ -52,12 +52,12 @@ set(libprotobuf_files
   #${protobuf_source_dir}/src/google/protobuf/wrappers.pb.cc
 )
 
-target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
 if (BUILD_SHARED_LIBS)
   add_library(libprotobuf SHARED ${libprotobuf_lite_files} ${libprotobuf_files})
 else (BUILD_SHARED_LIBS)
   add_library(libprotobuf STATIC ${libprotobuf_lite_files} ${libprotobuf_files})
 endif (BUILD_SHARED_LIBS)
+target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} ${CONAN_LIBS})
 set_target_properties(libprotobuf PROPERTIES
     COMPILE_DEFINITIONS LIBPROTOBUF_EXPORTS
     OUTPUT_NAME ${LIB_PREFIX}protobuf)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,5 +4,9 @@ cmake_minimum_required(VERSION 3.0)
 include(conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()
 
+if (MSVC)
+  add_definitions(/MP)
+endif (MSVC)
+
 ADD_EXECUTABLE(client client.cpp message.pb.cc)
 TARGET_LINK_LIBRARIES(client ${CONAN_LIBS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(MyHello)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 
 include(conanbuildinfo.cmake)
 CONAN_BASIC_SETUP()

--- a/test/conanfile.py
+++ b/test/conanfile.py
@@ -18,7 +18,9 @@ class ProtobufTestConan(ConanFile):
     def imports(self):
         self.copy("protoc.exe", "bin", "bin") # Windows
         self.copy("protoc", "bin", "bin") # Linux / Macos
-        self.copy("libproto*.9.dylib", "bin", "bin") # Macos (when options.static=False)
+        self.copy("libproto*.9.dylib", "bin", "bin") # Macos (when Protobuf:static=False)
+        self.copy("libproto*.dll", "bin", "bin") # Windows (when Protobuf:static=False)
+        self.copy("zlib*.dll", "bin", "bin") # Windows (when zlib:shared=True)
 
     def test(self):
         self.run(os.path.join(".", "bin", "client"))


### PR DESCRIPTION
- Windows: Turn `BUILD_SHARED_LIBS` option `ON`  when `static=False`
- Windows: Fix errors for Visual Studio 14:

```
error C2338: <hash_map> is deprecated and will be REMOVED. Please use <unordere
d_map>. You can define _SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS to acknowledge
that you have received this warning.
```
- Macos, Linux: Fixes for the issue that `settings.arch` is ignored
- All: Build protobuf with `zlib/1.2.8@lasote/stable`
- All: Makes build process faster by using `make -j` or `/MP`
- All: Run tests with `ConanMultiPacker`
