### PR TITLE
Paths with spaces need to be escaped on Windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,8 +11,8 @@ class ProtobufConan(ConanFile):
     requires = "zlib/1.2.8@lasote/stable"
     settings = "os", "compiler", "build_type", "arch"
     exports = "CMakeLists.txt", "lib*.cmake", "extract_includes.bat.in", "protoc.cmake", "tests.cmake", "change_dylib_names.sh"
-    options = {"shared": [True, False]}
-    default_options = "shared=True"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = "shared=True", "fPIC=False"
     generators = "cmake"
 
     def config(self):
@@ -38,6 +38,7 @@ class ProtobufConan(ConanFile):
         if self.settings.os == "Windows":
             args = ['-DBUILD_TESTING=OFF']
             args += ['-DBUILD_SHARED_LIBS=%s' % ('ON' if self.options.shared else 'OFF')]
+            args += ['-DCMAKE_POSITION_INDEPENDENT_CODE=%s' % ('ON' if self.options.fPIC else 'OFF')]
             cmake = CMake(self.settings)
             self.run('cd protobuf-2.6.1/cmake && cmake . %s %s' % (cmake.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1/cmake && cmake --build . %s" % cmake.build_config)

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,7 +59,8 @@ class ProtobufConan(ConanFile):
             if not self.options.shared:
                 args += ['--disable-shared']
             
-            args += ('"CFLAGS=-fPIC" "CXXFLAGS=-fPIC"' if self.options.shared else '')
+            if self.options.shared or self.options.fPIC:
+	        args += ['"CFLAGS=-fPIC" "CXXFLAGS=-fPIC"']
 
             self.run("cd protobuf-2.6.1 && %s ./configure %s" % (env.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1 && make -j %s" % concurrency)

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,6 @@ class ProtobufConan(ConanFile):
         if self.settings.os == "Windows":
             args = ['-DBUILD_TESTING=OFF']
             args += ['-DBUILD_SHARED_LIBS=%s' % ('ON' if self.options.shared else 'OFF')]
-            args += ['-DCMAKE_POSITION_INDEPENDENT_CODE=%s' % ('ON' if self.options.fPIC else 'OFF')]
             cmake = CMake(self.settings)
             self.run('cd protobuf-2.6.1/cmake && cmake . %s %s' % (cmake.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1/cmake && cmake --build . %s" % cmake.build_config)
@@ -59,6 +58,8 @@ class ProtobufConan(ConanFile):
             args = []
             if not self.options.shared:
                 args += ['--disable-shared']
+            
+            args += ('"CFLAGS=-fPIC" "CXXFLAGS=-fPIC"' if self.options.shared else '')
 
             self.run("cd protobuf-2.6.1 && %s ./configure %s" % (env.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1 && make -j %s" % concurrency)

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,7 +59,7 @@ class ProtobufConan(ConanFile):
             if not self.options.shared:
                 args += ['--disable-shared']
             
-            args += ('"CFLAGS=-fPIC" "CXXFLAGS=-fPIC"' if self.options.shared else '')
+            args += ('"CFLAGS=-fPIC" "CXXFLAGS=-fPIC"' if (self.options.shared || self.options.fPIC) else '')
 
             self.run("cd protobuf-2.6.1 && %s ./configure %s" % (env.command_line, ' '.join(args)))
             self.run("cd protobuf-2.6.1 && make -j %s" % concurrency)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -11,7 +11,7 @@ class ProtobufTestConan(ConanFile):
         self.run('%s ../../message.proto --proto_path=../.. --cpp_out="."'
                  % os.path.join('.', 'bin', 'protoc'))
         cmake = CMake(self.settings)
-        self.run('cmake %s %s' % (self.conanfile_directory, cmake.command_line))
+        self.run('cmake "%s" %s' % (self.conanfile_directory, cmake.command_line))
         self.run("cmake --build . %s" % cmake.build_config)
         if self.settings.os == "Macos":
             self.run("cd bin; for LINK_DESTINATION in $(otool -L client | grep libproto | cut -f 1 -d' '); do install_name_tool -change \"$LINK_DESTINATION\" \"@executable_path/$(basename $LINK_DESTINATION)\" client; done")


### PR DESCRIPTION
On Windows the `conanfile_directory` path needs to be either quoted or escaped if it contains spaces.
