### PR TITLE
Release/3.3.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -64,7 +64,7 @@ class ProtobufConan(ConanFile):
 
                 self.run("./autogen.sh", cwd=self._source_dir)
 
-                args = ['--disable-dependency-tracking', '--with-zlib']
+                args = ['--disable-dependency-tracking', '--with-zlib', '--prefix=%s/install-dir' % os.path.abspath(self._source_dir)]
                 if not self.options.shared:
                     args += ['--disable-shared']
                 if self.options.shared or self.options.fPIC:
@@ -72,49 +72,27 @@ class ProtobufConan(ConanFile):
 
                 self.run("./configure %s" % (' '.join(args)), cwd=self._source_dir)
                 self.run("make -j %s" % cpus, cwd=self._source_dir)
+                self.run("make install", cwd=self._source_dir)
 
     def package(self):
-        self.copy("*.h", "include", "%s/src" % self._source_dir)
-        self.copy("descriptor.proto", "include/google/protobuf", "protobuf-%s/src/google/protobuf" % self.version, keep_path=False)
-        self.copy("plugin.proto", "include/google/protobuf/compiler", "protobuf-%s/src/google/protobuf/compiler" % self.version, keep_path=False)
-
         if self.settings.os == "Windows":
-            if self.settings.compiler == "Visual Studio":
-                self.copy("*.lib", "lib", "%s/cmake" % self._source_dir, keep_path=False)
-            elif self.settings.compiler == "gcc":
-                self.copy("*.a", "lib", "%s/cmake" % self._source_dir, keep_path=False)
+            self.copy("*.h", "include", "%s/src" % self._source_dir)
+            self.copy("descriptor.proto", "include/google/protobuf", "protobuf-%s/src/google/protobuf" % self.version, keep_path=False)
+            self.copy("plugin.proto", "include/google/protobuf/compiler", "protobuf-%s/src/google/protobuf/compiler" % self.version, keep_path=False)
+            self.copy("*.lib", "lib", "%s/cmake" % self._source_dir, keep_path=False)
             self.copy("*.exe", "bin", "%s/cmake" % self._source_dir, keep_path=False)
 
             if self.options.shared:
                 self.copy("*.dll", "bin", "%s/cmake" % self._source_dir, keep_path=False)
         else:
-            if self.settings.os == "Macos":
-                if not self.options.shared:
-                    self.copy("protoc", "bin", "%s/src/" % self._source_dir, keep_path=False)
-                    self.copy("*.a", "lib", "%s/src/.libs" % self._source_dir, keep_path=False)
-                else:
-                    # Change *.dylib dependencies and ids to be relative to @executable_path
-                    self.run("bash ../../cmake/change_dylib_names.sh", cwd="%s/src/.libs" % self._source_dir)
-                    self.copy("*.dylib", "bin", "%s/src/.libs" % self._source_dir,
-                              keep_path=False, symlinks=True)
-                    self.copy("*.dylib", "lib", "%s/src/.libs" % self._source_dir,
-                              keep_path=False, symlinks=True)
-
-                    # "src/protoc" may be a wrapper shell script which execute "src/.libs/protoc".
-                    # Copy "src/.libs/protoc" instead of "src/protoc"
-                    self.copy("protoc", "bin", "%s/src/.libs/" % self._source_dir, keep_path=False)
-            else:
-                self.copy("protoc", "bin", "%s/src/" % self._source_dir, keep_path=False)
-                if not self.options.shared:
-                    self.copy("*.a", "lib", "%s/src/.libs" % self._source_dir, keep_path=False)
-                else:
-                    self.copy("*.so*", "lib", "%s/src/.libs" % self._source_dir, keep_path=False, symlinks=True)
+            self.copy("*", ".", "%s/install-dir" % self._source_dir)
 
     def package_info(self):
         if self.settings.os == "Windows":
-            lib_prefix = "lib" if self.settings.compiler == "Visual Studio" else ""
-            lib_suffix = "d" if self.settings.build_type == "Debug" else ""
-            self.cpp_info.libs = ["%sprotobuf%s" % (lib_prefix, lib_suffix)]
+            if self.settings.build_type == "Debug":
+                self.cpp_info.libs = ["libprotobufd"]
+            else:
+                self.cpp_info.libs = ["libprotobuf"]
             if self.options.shared:
                 self.cpp_info.defines = ["PROTOBUF_USE_DLLS"]
         elif self.settings.os == "Macos":

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,7 +64,7 @@ class ProtobufConan(ConanFile):
 
                 self.run("./autogen.sh", cwd=self._source_dir)
 
-                args = ['--disable-dependency-tracking', '--with-zlib', '--prefix=%s/install-dir' % os.path.abspath(self._source_dir)]
+                args = ['--disable-dependency-tracking', '--with-zlib']
                 if not self.options.shared:
                     args += ['--disable-shared']
                 if self.options.shared or self.options.fPIC:
@@ -72,27 +72,49 @@ class ProtobufConan(ConanFile):
 
                 self.run("./configure %s" % (' '.join(args)), cwd=self._source_dir)
                 self.run("make -j %s" % cpus, cwd=self._source_dir)
-                self.run("make install", cwd=self._source_dir)
 
     def package(self):
+        self.copy("*.h", "include", "%s/src" % self._source_dir)
+        self.copy("descriptor.proto", "include/google/protobuf", "protobuf-%s/src/google/protobuf" % self.version, keep_path=False)
+        self.copy("plugin.proto", "include/google/protobuf/compiler", "protobuf-%s/src/google/protobuf/compiler" % self.version, keep_path=False)
+
         if self.settings.os == "Windows":
-            self.copy("*.h", "include", "%s/src" % self._source_dir)
-            self.copy("descriptor.proto", "include/google/protobuf", "protobuf-%s/src/google/protobuf" % self.version, keep_path=False)
-            self.copy("plugin.proto", "include/google/protobuf/compiler", "protobuf-%s/src/google/protobuf/compiler" % self.version, keep_path=False)
-            self.copy("*.lib", "lib", "%s/cmake" % self._source_dir, keep_path=False)
+            if self.settings.compiler == "Visual Studio":
+                self.copy("*.lib", "lib", "%s/cmake" % self._source_dir, keep_path=False)
+            elif self.settings.compiler == "gcc":
+                self.copy("*.a", "lib", "%s/cmake" % self._source_dir, keep_path=False)
             self.copy("*.exe", "bin", "%s/cmake" % self._source_dir, keep_path=False)
 
             if self.options.shared:
                 self.copy("*.dll", "bin", "%s/cmake" % self._source_dir, keep_path=False)
         else:
-            self.copy("*", ".", "%s/install-dir" % self._source_dir)
+            if self.settings.os == "Macos":
+                if not self.options.shared:
+                    self.copy("protoc", "bin", "%s/src/" % self._source_dir, keep_path=False)
+                    self.copy("*.a", "lib", "%s/src/.libs" % self._source_dir, keep_path=False)
+                else:
+                    # Change *.dylib dependencies and ids to be relative to @executable_path
+                    self.run("bash ../../cmake/change_dylib_names.sh", cwd="%s/src/.libs" % self._source_dir)
+                    self.copy("*.dylib", "bin", "%s/src/.libs" % self._source_dir,
+                              keep_path=False, symlinks=True)
+                    self.copy("*.dylib", "lib", "%s/src/.libs" % self._source_dir,
+                              keep_path=False, symlinks=True)
+
+                    # "src/protoc" may be a wrapper shell script which execute "src/.libs/protoc".
+                    # Copy "src/.libs/protoc" instead of "src/protoc"
+                    self.copy("protoc", "bin", "%s/src/.libs/" % self._source_dir, keep_path=False)
+            else:
+                self.copy("protoc", "bin", "%s/src/" % self._source_dir, keep_path=False)
+                if not self.options.shared:
+                    self.copy("*.a", "lib", "%s/src/.libs" % self._source_dir, keep_path=False)
+                else:
+                    self.copy("*.so*", "lib", "%s/src/.libs" % self._source_dir, keep_path=False, symlinks=True)
 
     def package_info(self):
         if self.settings.os == "Windows":
-            if self.settings.build_type == "Debug":
-                self.cpp_info.libs = ["libprotobufd"]
-            else:
-                self.cpp_info.libs = ["libprotobuf"]
+            lib_prefix = "lib" if self.settings.compiler == "Visual Studio" else ""
+            lib_suffix = "d" if self.settings.build_type == "Debug" else ""
+            self.cpp_info.libs = ["%sprotobuf%s" % (lib_prefix, lib_suffix)]
             if self.options.shared:
                 self.cpp_info.defines = ["PROTOBUF_USE_DLLS"]
         elif self.settings.os == "Macos":


### PR DESCRIPTION
I was unable to use built in proto types with the existing package using proto3 syntax (did not try 2).  This seemed to be because protoc couldn't find its own proto include directory.  Using make install seems to fix this, though I have not tested for macos, nor made changes for windows...  

To reproduce the problem include a built in proto in a proto file, such as google/protobuf/struct.proto.