### PR TITLE
Removed installing g++ using SystemPackageTool

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class ProtobufConan(ConanFile):
     def system_requirements(self):
         if os_info.is_linux:
             installer = SystemPackageTool()
-            for pkg in ["autoconf", "automake", "libtool", "curl", "make", "g++", "unzip"]:
+            for pkg in ["autoconf", "automake", "libtool", "curl", "make", "unzip"]:
                 installer.install(pkg)
 
     def build(self):


### PR DESCRIPTION
I think it should not be specified in conanfile. g++ is obvious requirement.

What's more, under e.g. Centos, g++ is not installed from package g++, but from gcc-c++ and it's uncompilable